### PR TITLE
Support zephyr-crosstool-ng version handling

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -5,7 +5,7 @@ AC_PREREQ([2.67])
 
 AC_INIT(
     [crosstool-NG],
-    [m4_esyscmd_s([maintainer/git-version-gen --prefix crosstool-ng- .tarball-version])],
+    [m4_esyscmd_s([maintainer/git-version-gen --prefix zephyr-crosstool-ng- .tarball-version])],
     [crossgcc@sourceware.org],
     [crosstool-ng],
     [http://crosstool-ng.org])

--- a/scripts/crosstool-NG.sh
+++ b/scripts/crosstool-NG.sh
@@ -207,7 +207,7 @@ fi
 
 # Compute the package version string
 if [ "${CT_SHOW_CT_VERSION}" = "y" ]; then
-    CT_PKGVERSION="crosstool-NG ${CT_VERSION}${CT_TOOLCHAIN_PKGVERSION:+ - ${CT_TOOLCHAIN_PKGVERSION}}"
+    CT_PKGVERSION="zephyr-crosstool-NG ${CT_VERSION}${CT_TOOLCHAIN_PKGVERSION:+ - ${CT_TOOLCHAIN_PKGVERSION}}"
 else
     CT_PKGVERSION="${CT_TOOLCHAIN_PKGVERSION}"
 fi


### PR DESCRIPTION
This commit adds the support for handling zephyr-crosstool-ng versions.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>