### PR TITLE
ci: Fetch all history for all tags and branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,9 @@ jobs:
     - name: Check out source code
       uses: actions/checkout@v2
 
+    # Fetch all history for all tags and branches
+    - run: git fetch --prune --unshallow
+
     # Build crosstool-ng
     - name: Build crosstool-ng
       run: |


### PR DESCRIPTION
This is required for the `git-version-gen` script to function properly.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>