### PR TITLE
ci: Enable automatic artifact clean up

### DIFF
--- a/.github/workflows/remove-old-artifacts.yml
+++ b/.github/workflows/remove-old-artifacts.yml
@@ -1,0 +1,19 @@
+name: Remove old artifacts
+
+on:
+  schedule:
+    # Every day at 1am
+    - cron: '0 1 * * *'
+
+jobs:
+  remove-old-artifacts:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+    - name: Remove old artifacts
+      uses: c-hive/gha-remove-artifacts@v1
+      with:
+        age: '1 day'
+        skip-tags: true
+        skip-recent: 3


### PR DESCRIPTION
Enable automatic artifact clean up to prevent error messages like this:

```
Artifact storage quota has been hit. Unable to upload any new artifacts
```

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>