### PR TITLE
gdb: Use USERPROFILE to resolve home directory path on Windows

### DIFF
--- a/packages/gdb/8.3.1/0006-Use-USERPROFILE-environment-variable-to-resolve-home.patch
+++ b/packages/gdb/8.3.1/0006-Use-USERPROFILE-environment-variable-to-resolve-home.patch
@@ -1,0 +1,117 @@
+From 3a968096e09e3f31b52db03f8d5d526373c4867f Mon Sep 17 00:00:00 2001
+From: Stephanos Ioannidis <root@stephanos.io>
+Date: Wed, 27 May 2020 17:35:52 +0900
+Subject: [PATCH] Use USERPROFILE environment variable to resolve home path on
+ Windows
+
+`HOME` is not a default valid environment variable on Windows.
+
+`USERPROFILE` environment variable should be used to resolve the user
+home directory path.
+
+Signed-off-by: Stephanos Ioannidis <root@stephanos.io>
+---
+ gdb/auto-load.c          |  4 ++++
+ gdb/common/pathstuff.c   |  4 ++++
+ gdb/gnulib/import/glob.c | 22 ++--------------------
+ gdb/main.c               |  4 ++++
+ gdb/windows-nat.c        |  4 ++++
+ 5 files changed, 18 insertions(+), 20 deletions(-)
+
+diff --git a/gdb/auto-load.c b/gdb/auto-load.c
+index 00869fe0b1..d2bca00bf8 100644
+--- a/gdb/auto-load.c
++++ b/gdb/auto-load.c
+@@ -497,6 +497,10 @@ file_is_auto_load_safe (const char *filename, const char *debug_fmt, ...)
+   if (!advice_printed)
+     {
+       const char *homedir = getenv ("HOME");
++#ifdef _WIN32
++      if (homedir == NULL)
++	homedir = getenv ("USERPROFILE");
++#endif
+ 
+       if (homedir == NULL)
+ 	homedir = "$HOME";
+diff --git a/gdb/common/pathstuff.c b/gdb/common/pathstuff.c
+index 2b1669a5b9..42168406a5 100644
+--- a/gdb/common/pathstuff.c
++++ b/gdb/common/pathstuff.c
+@@ -231,6 +231,10 @@ get_standard_cache_dir ()
+ #endif
+ 
+   const char *home = getenv ("HOME");
++#ifdef _WIN32
++  if (home == NULL)
++    home = getenv ("USERPROFILE");
++#endif
+   if (home != NULL)
+     {
+       /* Make sure the path is absolute and tilde-expanded.  */
+diff --git a/gdb/gnulib/import/glob.c b/gdb/gnulib/import/glob.c
+index 4b04b902e5..53ac8c4f04 100644
+--- a/gdb/gnulib/import/glob.c
++++ b/gdb/gnulib/import/glob.c
+@@ -663,27 +663,9 @@ glob (const char *pattern, int flags, int (*errfunc) (const char *, int),
+           if (home_dir == NULL || home_dir[0] == '\0')
+             home_dir = "SYS:";
+ # else
+-#  ifdef WINDOWS32
+-          /* Windows NT defines HOMEDRIVE and HOMEPATH.  But give preference
+-             to HOME, because the user can change HOME.  */
++#  ifdef _WIN32
+           if (home_dir == NULL || home_dir[0] == '\0')
+-            {
+-              const char *home_drive = getenv ("HOMEDRIVE");
+-              const char *home_path = getenv ("HOMEPATH");
+-
+-              if (home_drive != NULL && home_path != NULL)
+-                {
+-                  size_t home_drive_len = strlen (home_drive);
+-                  size_t home_path_len = strlen (home_path);
+-                  char *mem = alloca (home_drive_len + home_path_len + 1);
+-
+-                  memcpy (mem, home_drive, home_drive_len);
+-                  memcpy (mem + home_drive_len, home_path, home_path_len + 1);
+-                  home_dir = mem;
+-                }
+-              else
+-                home_dir = "c:/users/default"; /* poor default */
+-            }
++            home_dir = getenv ("USERPROFILE");
+ #  else
+           if (home_dir == NULL || home_dir[0] == '\0')
+             {
+diff --git a/gdb/main.c b/gdb/main.c
+index e14dd06fa8..10ebfb94a1 100644
+--- a/gdb/main.c
++++ b/gdb/main.c
+@@ -248,6 +248,10 @@ get_init_files (const char **system_gdbinit,
+ 	}
+ 
+       homedir = getenv ("HOME");
++#ifdef _WIN32
++      if (homedir == NULL)
++        homedir = getenv ("USERPROFILE");
++#endif
+ 
+       /* If the .gdbinit file in the current directory is the same as
+ 	 the $HOME/.gdbinit file, it should not be sourced.  homebuf
+diff --git a/gdb/windows-nat.c b/gdb/windows-nat.c
+index 3add8e63f9..febaccb71b 100644
+--- a/gdb/windows-nat.c
++++ b/gdb/windows-nat.c
+@@ -3236,6 +3236,10 @@ _initialize_check_for_gdb_ini (void)
+     return;
+ 
+   homedir = getenv ("HOME");
++#ifdef _WIN32
++  if (homedir == NULL)
++    homedir = getenv ("USERPROFILE");
++#endif
+   if (homedir)
+     {
+       char *p;
+-- 
+2.26.2
+

--- a/packages/gdb/9.1/0005-Use-USERPROFILE-environment-variable-to-resolve-home.patch
+++ b/packages/gdb/9.1/0005-Use-USERPROFILE-environment-variable-to-resolve-home.patch
@@ -1,0 +1,117 @@
+From 15cff2bcc05a19660e47b0cbb09c09dfb67299b7 Mon Sep 17 00:00:00 2001
+From: Stephanos Ioannidis <root@stephanos.io>
+Date: Wed, 27 May 2020 17:35:52 +0900
+Subject: [PATCH] Use USERPROFILE environment variable to resolve home path on
+ Windows
+
+`HOME` is not a default valid environment variable on Windows.
+
+`USERPROFILE` environment variable should be used to resolve the user
+home directory path.
+
+Signed-off-by: Stephanos Ioannidis <root@stephanos.io>
+---
+ gdb/auto-load.c            |  4 ++++
+ gdb/gdbsupport/pathstuff.c |  4 ++++
+ gdb/main.c                 |  4 ++++
+ gdb/windows-nat.c          |  4 ++++
+ gnulib/import/glob.c       | 22 ++--------------------
+ 5 files changed, 18 insertions(+), 20 deletions(-)
+
+diff --git a/gdb/auto-load.c b/gdb/auto-load.c
+index 5a9f47f078..7f88967b82 100644
+--- a/gdb/auto-load.c
++++ b/gdb/auto-load.c
+@@ -499,6 +499,10 @@ file_is_auto_load_safe (const char *filename, const char *debug_fmt, ...)
+   if (!advice_printed)
+     {
+       const char *homedir = getenv ("HOME");
++#ifdef _WIN32
++      if (homedir == NULL)
++	homedir = getenv ("USERPROFILE");
++#endif
+ 
+       if (homedir == NULL)
+ 	homedir = "$HOME";
+diff --git a/gdb/gdbsupport/pathstuff.c b/gdb/gdbsupport/pathstuff.c
+index f9882a2635..a90587103c 100644
+--- a/gdb/gdbsupport/pathstuff.c
++++ b/gdb/gdbsupport/pathstuff.c
+@@ -231,6 +231,10 @@ get_standard_cache_dir ()
+ #endif
+ 
+   const char *home = getenv ("HOME");
++#ifdef _WIN32
++  if (home == NULL)
++    home = getenv ("USERPROFILE");
++#endif
+   if (home != NULL)
+     {
+       /* Make sure the path is absolute and tilde-expanded.  */
+diff --git a/gdb/main.c b/gdb/main.c
+index 66a9e6a6d2..2a7228f20c 100644
+--- a/gdb/main.c
++++ b/gdb/main.c
+@@ -300,6 +300,10 @@ get_init_files (std::vector<std::string> *system_gdbinit,
+ 	}
+ 
+       const char *homedir = getenv ("HOME");
++#ifdef _WIN32
++      if (homedir == NULL)
++        homedir = getenv ("USERPROFILE");
++#endif
+ 
+       /* If the .gdbinit file in the current directory is the same as
+ 	 the $HOME/.gdbinit file, it should not be sourced.  homebuf
+diff --git a/gdb/windows-nat.c b/gdb/windows-nat.c
+index 31a5cabfb3..e60298ff60 100644
+--- a/gdb/windows-nat.c
++++ b/gdb/windows-nat.c
+@@ -3201,6 +3201,10 @@ _initialize_check_for_gdb_ini (void)
+     return;
+ 
+   homedir = getenv ("HOME");
++#ifdef _WIN32
++  if (homedir == NULL)
++    homedir = getenv ("USERPROFILE");
++#endif
+   if (homedir)
+     {
+       char *p;
+diff --git a/gnulib/import/glob.c b/gnulib/import/glob.c
+index 416d210b63..eea1189e05 100644
+--- a/gnulib/import/glob.c
++++ b/gnulib/import/glob.c
+@@ -663,27 +663,9 @@ glob (const char *pattern, int flags, int (*errfunc) (const char *, int),
+           if (home_dir == NULL || home_dir[0] == '\0')
+             home_dir = "SYS:";
+ # else
+-#  ifdef WINDOWS32
+-          /* Windows NT defines HOMEDRIVE and HOMEPATH.  But give preference
+-             to HOME, because the user can change HOME.  */
++#  ifdef _WIN32
+           if (home_dir == NULL || home_dir[0] == '\0')
+-            {
+-              const char *home_drive = getenv ("HOMEDRIVE");
+-              const char *home_path = getenv ("HOMEPATH");
+-
+-              if (home_drive != NULL && home_path != NULL)
+-                {
+-                  size_t home_drive_len = strlen (home_drive);
+-                  size_t home_path_len = strlen (home_path);
+-                  char *mem = alloca (home_drive_len + home_path_len + 1);
+-
+-                  memcpy (mem, home_drive, home_drive_len);
+-                  memcpy (mem + home_drive_len, home_path, home_path_len + 1);
+-                  home_dir = mem;
+-                }
+-              else
+-                home_dir = "c:/users/default"; /* poor default */
+-            }
++            home_dir = getenv ("USERPROFILE");
+ #  else
+           if (home_dir == NULL || home_dir[0] == '\0')
+             {
+-- 
+2.26.2
+


### PR DESCRIPTION
This commit adds a patch to update the GDB to use the `USERPROFILE`
environment variable to resolve the home directory path on the MinGW
Windows environment.

Note that, strictly speaking, this is not necessary if the Windows GDB
executable is running under a POSIX emulation environment (e.g. MSYS2).

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>

Fixes #38