### PR TITLE
scripts: gdb: Fix incorrect option specification

### DIFF
--- a/scripts/build/debug/300-gdb.sh
+++ b/scripts/build/debug/300-gdb.sh
@@ -72,7 +72,6 @@ do_debug_gdb_build()
             prefix="${CT_PREFIX_DIR}" \
             static="${CT_GDB_CROSS_STATIC}" \
             static_libstdcxx="${CT_GDB_CROSS_STATIC_LIBSTDCXX}" \
-            --with-sysroot="${CT_SYSROOT_DIR}"          \
             "${cross_extra_config[@]}"
 
         if [ "${CT_BUILD_MANUALS}" = "y" ]; then


### PR DESCRIPTION
The `--with-sysroot` configuration option was incorrectly specified
through the `do_gdb_backend` function when it should be added to the
`configure` arguments.

This commit completely removes this option since it should not be
necessary and the problem it was trying to address should have been
fixed (see 911a3d473e2b27e00d89e50d0514f9ebc3baffbf).

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>