### PR TITLE
scripts: gdb: Ignore static libstdc++ on macOS

### DIFF
--- a/scripts/build/debug/300-gdb.sh
+++ b/scripts/build/debug/300-gdb.sh
@@ -258,11 +258,20 @@ do_gdb_backend()
         cflags+=" -static"
         ldflags+=" -static"
     fi
-    if [ "${static_libstdcxx}" = "y" ]; then
-        ldflags+=" -static-libgcc"
-        ldflags+=" -static-libstdc++"
-    fi
 
+    if [ "${static_libstdcxx}" = "y" ]; then
+        case "$CT_HOST" in
+            *darwin*)
+                # macOS builds with clang and provides a well known execution
+                # environment, so there is little point in static linking the
+                # C++ runtime library -- ignore this option for now.
+                ;;
+            *)
+                ldflags+=" -static-libgcc"
+                ldflags+=" -static-libstdc++"
+                ;;
+        esac
+    fi
 
     # Fix up whitespace. Some older GDB releases (e.g. 6.8a) get confused if there
     # are multiple consecutive spaces: sub-configure scripts replace them with a


### PR DESCRIPTION
GDB is built using the Clang compiler on the macOS, and `libstdc++`
and `libgcc` are not applicable for obvious reasons.

Since macOS provides a fairly well known and controlled execution
environment, there is little point in static linking the C++ runtime
library.

This commit updates the GDB build script to ignore the
`CT_GDB_*_STATIC_LIBSTDCXX` configuration on the macOS.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>