### PR TITLE
ci: Build Windows GDB with Python 3.6.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,7 +139,22 @@ jobs:
           cat <<EOF >> .config
         CT_CANADIAN=y
         CT_HOST="x86_64-w64-mingw32"
-        CT_GDB_CROSS_PYTHON=n
+        EOF
+        fi
+
+        # Configure Windows Python library
+        if [ "${{ matrix.host.name }}" == "windows-x86_64" ]; then
+          # Clone mingw-w64-libpython cross compilation kit
+          git clone \
+            https://github.com/stephanosio/mingw-w64-libpython.git \
+            ${WORKSPACE}/mingw-w64-libpython
+
+          # Use Python 3.6.8
+          export LIBPYTHON_KIT_ROOT=${WORKSPACE}/mingw-w64-libpython/python-3.6.8
+
+          # Set Python configuration resolver for GDB
+          cat <<EOF >> .config
+        CT_GDB_CROSS_PYTHON_BINARY="${LIBPYTHON_KIT_ROOT}/bin/python"
         EOF
         fi
 

--- a/patches/zephyr/gdb/8.3.1/0010-Make-GDB-compile-with-Python-3-on-MinGW.patch
+++ b/patches/zephyr/gdb/8.3.1/0010-Make-GDB-compile-with-Python-3-on-MinGW.patch
@@ -1,0 +1,114 @@
+From b2a2694ceb936c43c1dd58c66782f8d0f01e778b Mon Sep 17 00:00:00 2001
+From: Christian Biesinger <cbiesinger@google.com>
+Date: Tue, 13 Aug 2019 14:48:05 -0500
+Subject: [PATCH] Make GDB compile with Python 3 on MinGW
+
+PyFile_FromString and PyFile_AsFile have been removed in Python 3.
+There is no obvious replacement that works here, and we can't just
+pass our FILE* to a DLL in Windows because it may use a different
+C runtime.
+
+So we just call a Python function which reads and executes file
+contents. Care must be taken to execute it in the context of
+__main__.
+
+Tested by inverting the ifdef and running the testsuite on Debian
+Linux (even without the patch, I failed at running the testsuite
+on Windows). I did test with both Python 2 and 3.
+
+gdb/ChangeLog:
+
+2019-08-22  Christian Biesinger  <cbiesinger@google.com>
+
+	* python/lib/gdb/__init__.py (_execute_file): New function.
+	* python/python.c (python_run_simple_file): Call gdb._execute_file
+	on Windows.
+---
+ gdb/python/lib/gdb/__init__.py | 26 ++++++++++++++++++++++++++
+ gdb/python/python.c            | 25 +++++++++++++++----------
+ 2 files changed, 41 insertions(+), 10 deletions(-)
+
+diff --git a/gdb/python/lib/gdb/__init__.py b/gdb/python/lib/gdb/__init__.py
+index af74df80c8..afe5b08f3a 100644
+--- a/gdb/python/lib/gdb/__init__.py
++++ b/gdb/python/lib/gdb/__init__.py
+@@ -106,6 +106,32 @@ def execute_unwinders(pending_frame):
+ 
+     return None
+ 
++def _execute_file(filepath):
++    """This function is used to replace Python 2's PyRun_SimpleFile.
++
++    Loads and executes the given file.
++
++    We could use the runpy module, but its documentation says:
++    "Furthermore, any functions and classes defined by the executed code are
++    not guaranteed to work correctly after a runpy function has returned."
++    """
++    globals = sys.modules['__main__'].__dict__
++    set_file = False
++    # Set file (if not set) so that the imported file can use it (e.g. to
++    # access file-relative paths). This matches what PyRun_SimpleFile does.
++    if not hasattr(globals, '__file__'):
++        globals['__file__'] = filepath
++        set_file = True
++    try:
++        with open(filepath, 'rb') as file:
++            # We pass globals also as locals to match what Python does
++            # in PyRun_SimpleFile.
++            compiled = compile(file.read(), filepath, 'exec')
++            exec(compiled, globals, globals)
++    finally:
++        if set_file:
++            del globals['__file__']
++
+ 
+ # Convenience variable to GDB's python directory
+ PYTHONDIR = os.path.dirname(os.path.dirname(__file__))
+diff --git a/gdb/python/python.c b/gdb/python/python.c
+index c23db2c126..f7ab52375c 100644
+--- a/gdb/python/python.c
++++ b/gdb/python/python.c
+@@ -323,9 +323,8 @@ python_interactive_command (const char *arg, int from_tty)
+    A FILE * from one runtime does not necessarily operate correctly in
+    the other runtime.
+ 
+-   To work around this potential issue, we create on Windows hosts the
+-   FILE object using Python routines, thus making sure that it is
+-   compatible with the Python library.  */
++   To work around this potential issue, we run code in Python to load
++   the script.  */
+ 
+ static void
+ python_run_simple_file (FILE *file, const char *filename)
+@@ -339,14 +338,20 @@ python_run_simple_file (FILE *file, const char *filename)
+   /* Because we have a string for a filename, and are using Python to
+      open the file, we need to expand any tilde in the path first.  */
+   gdb::unique_xmalloc_ptr<char> full_path (tilde_expand (filename));
+-  gdbpy_ref<> python_file (PyFile_FromString (full_path.get (), (char *) "r"));
+-  if (python_file == NULL)
+-    {
+-      gdbpy_print_stack ();
+-      error (_("Error while opening file: %s"), full_path.get ());
+-    }
+ 
+-  PyRun_SimpleFile (PyFile_AsFile (python_file.get ()), filename);
++  if (gdb_python_module == nullptr
++      || ! PyObject_HasAttrString (gdb_python_module, "_execute_file"))
++    error (_("Installation error: gdb._execute_file function is missing"));
++
++  gdbpy_ref<> return_value
++    (PyObject_CallMethod (gdb_python_module, "_execute_file", "s",
++			  full_path.get ()));
++  if (return_value == nullptr)
++    {
++      /* Use PyErr_PrintEx instead of gdbpy_print_stack to better match the
++         behavior of the non-Windows codepath.  */
++      PyErr_PrintEx(0);
++    }
+ 
+ #endif /* _WIN32 */
+ }
+-- 
+2.26.2
+


### PR DESCRIPTION
This commit updates the CI workflow to clone the libpython cross
compilation kit and use it to build the Windows GDB executables against
the libpython 3.6.8.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>

Fixes #11