### PR TITLE
scripts: build: Discard locals when stripping target libraries

### DIFF
--- a/scripts/build/internals.sh
+++ b/scripts/build/internals.sh
@@ -158,9 +158,11 @@ strip_target_lib()
 {
     local strip_args
 
-    strip_args="-R .comment -R .note -R .debug_info -R .debug_aranges
-    -R .debug_pubnames -R .debug_pubtypes -R .debug_abbrev -R .debug_line
-    -R .debug_str -R .debug_ranges -R .debug_loc
+    strip_args="
+        --discard-locals
+        -R .comment -R .note -R .debug_info -R .debug_aranges
+        -R .debug_pubnames -R .debug_pubtypes -R .debug_abbrev -R .debug_line
+        -R .debug_str -R .debug_ranges -R .debug_loc
         "
 
     find "$1" -name "$2" | while read target_lib; do


### PR DESCRIPTION
Some target libraries (e.g. newlib for RISC-V) may contain local
symbol information when built with the `-g` flag.

This commit adds the `--discard-locals` flag to discard all the
unnecessary local symbols from the object files.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>

Fixes #49