### PR TITLE
scripts: newlib: Copy libgloss nano variant

### DIFF
--- a/scripts/build/libc/newlib.sh
+++ b/scripts/build/libc/newlib.sh
@@ -263,6 +263,11 @@ newlib_copy_nano_multilibs()
     CT_DoExecLog ALL cp -f "${nano_lib_dir}/${CT_TARGET}/lib/${multi_dir}/libg.a" \
                            "${CT_PREFIX_DIR}/${CT_TARGET}/lib/${multi_dir}/libg_nano.a"
 
+    if [ -f ${nano_lib_dir}/${CT_TARGET}/lib/${multi_dir}/libgloss.a ]; then
+        CT_DoExecLog ALL cp -f "${nano_lib_dir}/${CT_TARGET}/lib/${multi_dir}/libgloss.a" \
+                               "${CT_PREFIX_DIR}/${CT_TARGET}/lib/${multi_dir}/libgloss_nano.a"
+    fi
+
     if [ -f ${nano_lib_dir}/${CT_TARGET}/lib/${multi_dir}/librdimon.a ]; then
         CT_DoExecLog ALL cp -f "${nano_lib_dir}/${CT_TARGET}/lib/${multi_dir}/librdimon.a" \
                                "${CT_PREFIX_DIR}/${CT_TARGET}/lib/${multi_dir}/librdimon_nano.a"


### PR DESCRIPTION
This commit updates the newlib build script to copy the libgloss
library from the nano variant build to `libgloss_nano.a` as per the
`nano.specs`.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>

Fixes #41