### PR TITLE
ci: Clean up libboost build directory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,9 @@ jobs:
           toolset=gcc-mingw link=static threading=multi variant=release \
           --prefix=/usr/x86_64-w64-mingw32
 
+        # Clean up build directory to save disk space
         popd
+        sudo rm -rf ${HOME}/boost
 
     # Check out source code
     - name: Check out source code


### PR DESCRIPTION
This commit updates the CI workflow to clean up the libboost build
directory after installation in order to save disk space on the build
machine.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>