### PR TITLE
patches: zephyr: newlib: Add host config for Zephyr

### DIFF
--- a/patches/zephyr/newlib/3.3.0/0004-newlib-configure.host-Add-host-config-for-zephyr.patch
+++ b/patches/zephyr/newlib/3.3.0/0004-newlib-configure.host-Add-host-config-for-zephyr.patch
@@ -1,0 +1,40 @@
+From 463470b901b572eb27d3bc35c5681d18a3b202d3 Mon Sep 17 00:00:00 2001
+From: Kumar Gala <kumar.gala@linaro.org>
+Date: Thu, 21 May 2020 22:55:16 -0500
+Subject: [PATCH] newlib/configure.host: Add host config for zephyr
+
+Add zephyr specific host config so that all arch toolchain variants we
+build for zephyr behave the same way.  (otherwise we end up getting
+-DMISSING_SYSCALL_NAMES set on some arch's like NIOS and x86, but not on
+others).
+
+Signed-off-by: Kumar Gala <kumar.gala@linaro.org>
+---
+ newlib/configure.host | 11 +++++++++++
+ 1 file changed, 11 insertions(+)
+
+diff --git a/newlib/configure.host b/newlib/configure.host
+index 048cf50d7..772f55bdd 100644
+--- a/newlib/configure.host
++++ b/newlib/configure.host
+@@ -687,6 +687,17 @@ newlib_cflags="${newlib_cflags} -DCLOCK_PROVIDED -DMALLOC_PROVIDED -DEXIT_PROVID
+   *-*-tirtos*)
+ 	newlib_cflags="${newlib_cflags} -D__DYNAMIC_REENT__ -DMALLOC_PROVIDED"
+ 	;;
++  *-zephyr-*)
++	syscall_dir=syscalls
++	case "${host}" in
++	  arm*-*-*)
++		if [ "x${newlib_may_supply_syscalls}" = "xyes" ] ; then
++		  newlib_cflags="${newlib_cflags} -DARM_RDI_MONITOR"
++		fi
++		;;
++	  *)
++	esac
++	;;
+ # UDI doesn't have exec, so system() should fail the right way
+   a29k-amd-udi)
+ 	newlib_cflags="${newlib_cflags} -DNO_EXEC"
+-- 
+2.26.2
+


### PR DESCRIPTION
This commit adds a newlib patch that defines the Zephyr host type with
the Zephyr-specific configurations.

This ensures that the newlib is consistently configured for all
supported architectures.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>

Closes #65