### PR TITLE
ci: Pull libboost from GitHub

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,10 +75,32 @@ jobs:
         mkdir -p ${HOME}/boost
         pushd ${HOME}/boost
 
-        # Download and extract Boost library source code
-        wget https://dl.bintray.com/boostorg/release/1.73.0/source/boost_1_73_0.tar.gz
-        tar xvf boost_1_73_0.tar.gz
-        cd boost_1_73_0
+        # Check out Boost library source code
+        git clone \
+          --branch boost-1.73.0 --depth=1 \
+          https://github.com/boostorg/boost.git \
+          src
+
+        cd src
+
+        # Check out Boost.Regex and its dependencies
+        git submodule update --init --depth=1 tools/build
+        git submodule update --init --depth=1 tools/boost_install
+        git submodule update --init --depth=1 libs/assert
+        git submodule update --init --depth=1 libs/core
+        git submodule update --init --depth=1 libs/config
+        git submodule update --init --depth=1 libs/container_hash
+        git submodule update --init --depth=1 libs/detail
+        git submodule update --init --depth=1 libs/headers
+        git submodule update --init --depth=1 libs/integer
+        git submodule update --init --depth=1 libs/mpl
+        git submodule update --init --depth=1 libs/predef
+        git submodule update --init --depth=1 libs/preprocessor
+        git submodule update --init --depth=1 libs/regex
+        git submodule update --init --depth=1 libs/smart_ptr
+        git submodule update --init --depth=1 libs/static_assert
+        git submodule update --init --depth=1 libs/throw_exception
+        git submodule update --init --depth=1 libs/type_traits
 
         # Bootstrap builder
         ./bootstrap.sh --with-toolset=gcc --with-libraries=regex --without-icu


### PR DESCRIPTION
This commit updates the CI workflow to pull the Boost library source
code from a GitHub address.

This ensures that there is no build failure from broken third-party
links.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>